### PR TITLE
Add variable for default Dell R710 iDRAC Encryption Key

### DIFF
--- a/R710-IPMI-TEMP/R710-IPMIStatic.sh
+++ b/R710-IPMI-TEMP/R710-IPMIStatic.sh
@@ -15,8 +15,9 @@
 IPMIHOST=10.0.100.20
 IPMIUSER=root
 IPMIPW=calvin
+IPMIEK=0000000000000000000000000000000000000000
 
 printf "Activating manual fan speeds! (2160 RPM)" | systemd-cat -t R710-IPMI-TEMP
 echo "Activating manual fan speeds! (2160 RPM)" | slacktee.sh -t "R710-IPMI-TEMP [$(hostname)]"
-ipmitool -I lanplus -H $IPMIHOST -U $IPMIUSER -P $IPMIPW raw 0x30 0x30 0x01 0x00
-ipmitool -I lanplus -H $IPMIHOST -U $IPMIUSER -P $IPMIPW raw 0x30 0x30 0x02 0xff 0x09
+ipmitool -I lanplus -H $IPMIHOST -U $IPMIUSER -P $IPMIPW -y $IPMIEK raw 0x30 0x30 0x01 0x00
+ipmitool -I lanplus -H $IPMIHOST -U $IPMIUSER -P $IPMIPW -y $IPMIEK raw 0x30 0x30 0x02 0xff 0x09

--- a/R710-IPMI-TEMP/R710-IPMITemp.sh
+++ b/R710-IPMI-TEMP/R710-IPMITemp.sh
@@ -16,6 +16,7 @@
 IPMIHOST=10.0.100.20
 IPMIUSER=root
 IPMIPW=calvin
+IPMIEK=0000000000000000000000000000000000000000
 
 # TEMPERATURE
 # Change this to the temperature in celcius you are comfortable with.
@@ -24,14 +25,14 @@ MAXTEMP=27
 
 # This variable sends a IPMI command to get the temperature, and outputs it as two digits.
 # Do not edit unless you know what you do.
-TEMP=$(ipmitool -I lanplus -H $IPMIHOST -U $IPMIUSER -P $IPMIPW sdr type temperature |grep Ambient |grep degrees |grep -Po '\d{2}' | tail -1)
+TEMP=$(ipmitool -I lanplus -H $IPMIHOST -U $IPMIUSER -P $IPMIPW -y $IPMIEK sdr type temperature |grep Ambient |grep degrees |grep -Po '\d{2}' | tail -1)
 
 
 if [[ $TEMP > $MAXTEMP ]];
   then
     printf "Warning: Temperature is too high! Activating dynamic fan control! ($TEMP C)" | systemd-cat -t R710-IPMI-TEMP
     echo "Warning: Temperature is too high! Activating dynamic fan control! ($TEMP C)" | /usr/bin/slacktee.sh -t "R710-IPMI-TEMP [$(hostname)]"
-    ipmitool -I lanplus -H $IPMIHOST -U $IPMIUSER -P $IPMIPW raw 0x30 0x30 0x01 0x01
+    ipmitool -I lanplus -H $IPMIHOST -U $IPMIUSER -P $IPMIPW -y $IPMIEK raw 0x30 0x30 0x01 0x01
   else
     # healthchecks.io
     curl -fsS --retry 3 https://hchk.io/XXX >/dev/null 2>&1


### PR DESCRIPTION
Adds the variable "IPMIEK" which gets sent along when interfacing with the iDRAC. The value is the default hexadecimal value set in the iDRAC. This enables the Encryption Key to be changed without additional code modifications.